### PR TITLE
Raw array based nearest-neighbor lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(pys2index MODULE src/main.cpp)
 
 target_include_directories(pys2index PUBLIC
   ${pys2index_INCLUDE_DIR}
+  ${xtensor_INCLUDE_DIRS}
   ${xtensor-python_INCLUDE_DIRS}
   ${Python_NumPy_INCLUDE_DIRS}
   ${pybind11_INCLUDE_DIRS}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,31 @@
 
 #include "pys2index/s2pointindex.hpp"
 
+#include "s2/s2latlng.h"
+#include "s2/s2cell_id.h"
+
 namespace py = pybind11;
+
+
+class get_cell_ids
+{
+public:
+    get_cell_ids() = default;
+
+    xt::pytensor<uint64, 1> operator()(xt::pytensor<double, 2> &latlon_points)
+    {
+        auto shape = latlon_points.shape();
+        auto cell_ids = xt::pytensor<uint64, 1>::from_shape({shape[0]});
+
+        for (auto i=0; i<shape[0]; ++i)
+        {
+            S2CellId cell(S2LatLng::FromDegrees(latlon_points(i, 0), latlon_points(i, 1)));
+            cell_ids(i) = cell.id();
+        }
+
+        return cell_ids;
+    }
+};
 
 
 PYBIND11_MODULE(pys2index, m)
@@ -44,5 +68,25 @@ PYBIND11_MODULE(pys2index, m)
         )pbdoc")
         .def("query", &s2point_index::query<float>,
              "Query the index for nearest neighbors (float version).");
+
+    py::class_<get_cell_ids> py_get_cell_ids(m, "get_cell_ids", R"pbdoc(
+        Get S2 cell ids of lat/lon coordinate points.
+
+        Parameters
+        ----------
+        latlon_points : array-like of shape (n_points, 2)
+            2-d array of query point coordinates (latitude, longitude) in degrees.
+
+        Returns
+        -------
+        cell_ids : array-like of shape (n_points)
+            1-d array of S2 cell ids of each point (dtype: uint64).
+
+    )pbdoc");
+    py_get_cell_ids.def(py::init<>());
+    py_get_cell_ids.def("__call__", &get_cell_ids::operator(), py::call_guard<py::gil_scoped_release>());
+    py_get_cell_ids.def("__reduce__", [py_get_cell_ids](const get_cell_ids &self) {
+        return py::make_tuple(py_get_cell_ids, py::tuple());
+    });
 
 }


### PR DESCRIPTION
The idea is to rely only on raw array operations to perform nearest-neighbor lookup, i.e., not using any tree-based data structure for the index.

Those complex structures are hard to reuse in distributed settings (e.g., using dask).

s2geometry provide some nice features like region coverings that may optimize the problem (well) beyond brute-force lookup.