### PR TITLE
Review GIL release policies

### DIFF
--- a/include/pys2index/s2pointindex.hpp
+++ b/include/pys2index/s2pointindex.hpp
@@ -88,6 +88,8 @@ namespace pys2index
         auto n_points = latlon_points.shape()[0];
         m_cell_ids.resize({n_points});
 
+        py::gil_scoped_release release;
+
         for (auto i=0; i<n_points; ++i)
         {
             S2CellId c(S2LatLng::FromDegrees(latlon_points(i, 0), latlon_points(i, 1)));
@@ -96,11 +98,14 @@ namespace pys2index
             m_index.Add(c.ToPoint(), static_cast<npy_intp>(i));
         }
 
+        py::gil_scoped_acquire acquire;
     }
 
     void s2point_index::insert_cell_ids()
     {
         auto num_points = m_cell_ids.size();
+
+        py::gil_scoped_release release;
 
         for (std::size_t i=0; i<num_points; ++i)
         {
@@ -108,6 +113,7 @@ namespace pys2index
             m_index.Add(c.ToPoint(), static_cast<npy_intp>(i));
         }
 
+        py::gil_scoped_acquire acquire;
     }
 
     template <class T>
@@ -116,6 +122,8 @@ namespace pys2index
         auto n_points = latlon_points.shape()[0];
         auto distances = distances_type<T>::from_shape({n_points});
         auto positions = positions_type::from_shape({n_points});
+
+        py::gil_scoped_release release;
 
         S2ClosestPointQuery<npy_intp> query(&m_index);
 
@@ -129,6 +137,8 @@ namespace pys2index
             distances(i) = static_cast<T>(results.distance().degrees());
             positions(i) = static_cast<npy_intp>(results.data());
         }
+
+        py::gil_scoped_acquire acquire;
 
         return std::make_tuple(std::move(distances), std::move(positions));
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,12 +36,11 @@ PYBIND11_MODULE(pys2index, m)
             2-d array of point coordinates (latitude, longitude) in degrees.
     )pbdoc");
 
-    py_s2pointindex.def(py::init(&pys2::s2point_index::from_points<double>), py::call_guard<py::gil_scoped_release>());
-    py_s2pointindex.def(py::init(&pys2::s2point_index::from_points<float>), py::call_guard<py::gil_scoped_release>());
-    py_s2pointindex.def(py::init(&pys2::s2point_index::from_cell_ids), py::call_guard<py::gil_scoped_release>());
+    py_s2pointindex.def(py::init(&pys2::s2point_index::from_points<double>));
+    py_s2pointindex.def(py::init(&pys2::s2point_index::from_points<float>));
+    py_s2pointindex.def(py::init(&pys2::s2point_index::from_cell_ids));
 
     py_s2pointindex.def("query", &pys2::s2point_index::query<double>,
-                        py::call_guard<py::gil_scoped_release>(),
                         R"pbdoc(
         Query the index for nearest neighbors.
 
@@ -58,11 +57,10 @@ PYBIND11_MODULE(pys2index, m)
             Indices of the nearest neighbor of the corresponding points.
 
     )pbdoc");
-    py_s2pointindex.def("query", &pys2::s2point_index::query<float>, py::call_guard<py::gil_scoped_release>(),
+    py_s2pointindex.def("query", &pys2::s2point_index::query<float>,
         "Query the index for nearest neighbors (float version).");
 
     py_s2pointindex.def("get_cell_ids", &pys2::s2point_index::get_cell_ids,
-                        py::call_guard<py::gil_scoped_release>(),
                         py::return_value_policy::move);
 
     py_s2pointindex.def(py::pickle(


### PR DESCRIPTION
With some numpy versions (1.19, 1.23), releasing the GIL for a whole method (i.e., using ``py::call_guard<py::gil_scoped_release>()``) where new numpy arrays (pytensor) were created or resized was causing segmentation faults. The GIL is now released at a more fine grained level inside the methods.