### PR TITLE
Add Pypi publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,11 @@ Repository = "https://github.com/benbovy/pys2index"
 
 [project.optional-dependencies]
 test = ["pytest>=6.0"]
+
+[tool.scikit-build]
+sdist.exclude = [
+    ".clang-format",
+    ".gitignore",
+    ".pre-commit-config.yaml",
+    ".github",
+]


### PR DESCRIPTION
This PR aims to add publishing of the source distribution to Pypi.
Preparations for #6.

As a first step, I have tidied up the sdist contents by removing some superfluous files.
The sdist already looks good, so I think the next step is manual publishing to Pypi and then adding of a Github action here that automatically publishes on release.

Since Pypi doesn't really support organizational accounts yet, how should we do this, @benbovy? Do you want it to be published under your account first, or should I go ahead and publish it under mine and then add you as a maintainer?