### PR TITLE
tbb support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
 find_package(s2 REQUIRED)
 
+find_package(TBB)
+if(TBB_FOUND)
+    message(STATUS "Found tbb v${TBB_VERSION}: ${TBB_INCLUDE_DIRS}")
+endif()
+
 # Build
 # =====
 
@@ -67,6 +72,9 @@ target_link_libraries(pys2index PRIVATE
   Python::NumPy
   s2
   )
+if(TBB_FOUND)
+    target_link_libraries(pys2index PRIVATE TBB::tbb)
+endif()
 
 pybind11_extension(pys2index)
 if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)

--- a/include/pys2index/s2pointindex.hpp
+++ b/include/pys2index/s2pointindex.hpp
@@ -14,7 +14,6 @@
 #include "xtensor-python/pyarray.hpp"
 #include "xtensor/xmanipulation.hpp"
 #include "xtensor/xview.hpp"
-#include "xtensor/xsort.hpp"
 
 #if __has_include("tbb/parallel_for.h")
 #define S2POINTINDEX_TBB
@@ -108,8 +107,10 @@ namespace pys2index
 
         py::gil_scoped_release release;
 #ifdef S2POINTINDEX_TBB
+        // indexing is very fast so we should not allow too small chunks
+        std::size_t chuncksize = 1024;
         tbb::parallel_for(
-            tbb::blocked_range<std::size_t>(0, n_points),
+            tbb::blocked_range<std::size_t>(0, n_points, chuncksize),
             [&](tbb::blocked_range<std::size_t> r)
             {
                 for (std::size_t i = r.begin(); i < r.end(); ++i)

--- a/include/pys2index/s2pointindex.hpp
+++ b/include/pys2index/s2pointindex.hpp
@@ -26,7 +26,6 @@
 #include "s2/s2latlng.h"
 #include "s2/s2point.h"
 #include "s2/s2point_index.h"
-//#include "s2/s2earth.h"
 #include "s2/s1chord_angle.h"
 
 namespace py = pybind11;
@@ -178,13 +177,11 @@ namespace pys2index
           if (!std::isinf(max_distance))
           {
             query.mutable_options()->set_max_distance(
-              //S2Earth::MetersToAngle(max_distance));
               S1ChordAngle::Degrees(max_distance));
           }
           if (max_error > 0.0)
           {
             query.mutable_options()->set_max_error(
-              //S2Earth::MetersToAngle(max_error));
               S1ChordAngle::Degrees(max_error));
           }
 #ifdef S2POINTINDEX_TBB
@@ -197,7 +194,6 @@ namespace pys2index
             S2ClosestPointQuery<npy_intp>::PointTarget target(point);
             std::size_t n = 0;
             for (const auto& result : query.FindClosestPoints(&target)) {
-              //distances(i, n) = static_cast<T>(S2Earth::ToMeters(result.distance()));
               distances(i, n) = static_cast<T>(result.distance().degrees());
               positions(i, n) = static_cast<npy_intp>(result.data());
               n++;

--- a/include/pys2index/s2pointindex.hpp
+++ b/include/pys2index/s2pointindex.hpp
@@ -2,6 +2,7 @@
 #define __S2POINTINDEX_H_
 
 #include <tuple>
+#include <cmath>
 
 #include "pybind11/pybind11.h"
 
@@ -10,12 +11,22 @@
 
 #define FORCE_IMPORT_ARRAY
 #include "xtensor-python/pytensor.hpp"
+#include "xtensor-python/pyarray.hpp"
+#include "xtensor/xmanipulation.hpp"
+#include "xtensor/xview.hpp"
+#include "xtensor/xsort.hpp"
+
+#if __has_include("tbb/parallel_for.h")
+#  define S2POINTINDEX_TBB
+#  include "tbb/parallel_for.h"
+#endif
 
 #include "s2/s2cell_id.h"
 #include "s2/s2closest_point_query.h"
 #include "s2/s2latlng.h"
 #include "s2/s2point.h"
 #include "s2/s2point_index.h"
+#include "s2/s2earth.h"
 
 namespace py = pybind11;
 
@@ -28,10 +39,12 @@ namespace pys2index
     public:
         using index_type = S2PointIndex<npy_intp>;
         using cell_ids_type = xt::pytensor<uint64, 1>;
-        using positions_type = xt::pytensor<npy_intp, 1>;
+
+        // the dimension is not known for query results, so use pyarray
+        using positions_type = xt::pyarray<npy_intp>;
 
         template <class T>
-        using distances_type = xt::pytensor<T, 1>;
+        using distances_type = xt::pyarray<T>;
 
         template <class T>
         using query_return_type = std::tuple<distances_type<T>, positions_type>;
@@ -47,9 +60,15 @@ namespace pys2index
         static std::unique_ptr<s2point_index> from_cell_ids(const cell_ids_type& cell_ids);
 
         template <class T>
-        query_return_type<T> query(const points_type<T>& latlon_points);
+        query_return_type<T> query(const points_type<T>& latlon_points,
+                                   const long unsigned int k,
+                                   const double eps,
+                                   const double distance_upper_bound);
 
         cell_ids_type get_cell_ids();
+        
+        template <class T>
+        static cell_ids_type to_cell_ids(const points_type<T>& latlon_points);
 
     private:
         index_type m_index;
@@ -82,22 +101,36 @@ namespace pys2index
     }
 
     template <class T>
-    void s2point_index::insert_latlon_points(const points_type<T>& latlon_points)
+    auto s2point_index::to_cell_ids(const points_type<T>& latlon_points) -> cell_ids_type
     {
         auto n_points = latlon_points.shape()[0];
-        m_cell_ids.resize({ n_points });
+        auto cell_ids = cell_ids_type::from_shape({ n_points });
 
         py::gil_scoped_release release;
-
-        for (auto i = 0; i < n_points; ++i)
+#ifdef S2POINTINDEX_TBB
+        tbb::parallel_for(tbb::blocked_range<std::size_t>(0, n_points),
+                          [&](tbb::blocked_range<std::size_t> r) 
         {
-            S2CellId c(S2LatLng::FromDegrees(latlon_points(i, 0), latlon_points(i, 1)));
-
-            m_cell_ids(i) = c.id();
-            m_index.Add(c.ToPoint(), static_cast<npy_intp>(i));
-        }
-
+           for (std::size_t i=r.begin(); i<r.end(); ++i)
+#else
+           for (std::size_t i = 0; i < n_points; ++i)
+#endif
+           {
+              S2CellId c(S2LatLng::FromDegrees(latlon_points(i, 0), latlon_points(i, 1)));
+              cell_ids(i) = c.id();
+           }
+#ifdef S2POINTINDEX_TBB
+        });
+#endif
         py::gil_scoped_acquire acquire;
+        return cell_ids;
+    }
+
+    template <class T>
+    void s2point_index::insert_latlon_points(const points_type<T>& latlon_points)
+    {
+        m_cell_ids = s2point_index::to_cell_ids(latlon_points);
+        this->insert_cell_ids();
     }
 
     void s2point_index::insert_cell_ids()
@@ -116,30 +149,63 @@ namespace pys2index
     }
 
     template <class T>
-    auto s2point_index::query(const points_type<T>& latlon_points) -> query_return_type<T>
+    auto s2point_index::query(
+        const points_type<T>& latlon_points,
+        const std::size_t k,
+        const double eps,
+        const double distance_upper_bound) -> query_return_type<T>
     {
         auto n_points = latlon_points.shape()[0];
-        auto distances = distances_type<T>::from_shape({ n_points });
-        auto positions = positions_type::from_shape({ n_points });
+        auto distances = distances_type<T>::from_shape({ n_points, k });
+        auto positions = positions_type::from_shape({ n_points, k });
 
         py::gil_scoped_release release;
-
-        S2ClosestPointQuery<npy_intp> query(&m_index);
-
-        for (auto i = 0; i < n_points; ++i)
+#ifndef S2POINTINDEX_TBB
+        distances.fill(std::numeric_limits<T>::infinity());
+        positions.fill(n_points);
+#else
+        tbb::parallel_for(tbb::blocked_range<std::size_t>(0, n_points),
+                          [&](tbb::blocked_range<std::size_t> r) 
         {
+          auto dview = xt::view(distances, xt::range(r.begin(), r.end()), xt::all());
+          dview.fill(std::numeric_limits<T>::infinity());
+          auto pview = xt::view(positions, xt::range(r.begin(), r.end()), xt::all());
+          pview.fill(n_points);
+#endif    
+          S2ClosestPointQuery<npy_intp> query(&m_index);
+          query.mutable_options()->set_max_results(k);
+          if (!std::isinf(distance_upper_bound))
+          {
+            query.mutable_options()->set_max_distance(
+              S2Earth::MetersToAngle(distance_upper_bound));
+          }
+          if (eps > 0.0)
+          {
+            query.mutable_options()->set_max_error(S2Earth::MetersToAngle(eps));
+          }
+#ifdef S2POINTINDEX_TBB
+          for (std::size_t i=r.begin(); i<r.end(); ++i)
+#else
+          for (std::size_t i = 0; i < n_points; ++i)
+#endif
+          {
             S2Point point(S2LatLng::FromDegrees(latlon_points(i, 0), latlon_points(i, 1)));
             S2ClosestPointQuery<npy_intp>::PointTarget target(point);
-
-            auto results = query.FindClosestPoint(&target);
-
-            distances(i) = static_cast<T>(results.distance().degrees());
-            positions(i) = static_cast<npy_intp>(results.data());
-        }
-
+            std::size_t n = 0;
+            for (const auto& result : query.FindClosestPoints(&target)) {
+              distances(i, n) = static_cast<T>(S2Earth::ToMeters(result.distance()));
+              positions(i, n) = static_cast<npy_intp>(result.data());
+              n++;
+            }
+          }
+#ifdef S2POINTINDEX_TBB
+        });
+#endif
         py::gil_scoped_acquire acquire;
 
-        return std::make_tuple(std::move(distances), std::move(positions));
+        return std::make_tuple(
+          std::move(xt::squeeze(distances)),
+          std::move(xt::squeeze(positions)));
     }
 
     auto s2point_index::get_cell_ids() -> cell_ids_type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ Repository = "https://github.com/benbovy/pys2index"
 
 [project.optional-dependencies]
 test = ["pytest>=6.0"]
+tbb = ["tbb", "tbb-devel"]
 
 [tool.scikit-build]
 sdist.exclude = [

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,26 +73,34 @@ PYBIND11_MODULE(pys2index, m)
         ----------
         latlon_points : ndarray of shape (n_points, 2), dtype=double
             2-d array of query point coordinates (latitude, longitude) in degrees.
+        max_results : int
+            Maximum number of nearest neighbors to return
+        max_error : double
+            Specifies that points up to max_error further away than the true
+            closest points may be substituted in the result set (in degrees).
+        max_distance : double
+            Specifies that only points whose distance to the target is less than
+            "max_distance" should be returned (in degrees).
 
         Returns
         -------
-        distances : ndarray of shape (n_points,), dtype=double
+        distances : ndarray of shape (n_points,) if k=1 else (n_points, k), dtype=double
             Distance to the nearest neighbor of the cooresponding points (in degrees).
-        positions : ndarray of shape (n_points,), dtype=int
+        positions : ndarray of shape (n_points,) if k=1 else (n_points, k), dtype=int
             Indices of the nearest neighbor of the corresponding points.
 
     )pbdoc",
                         py::arg("latlon_points"),
-                        py::arg("k") = 1,
-                        py::arg("eps") = 0., 
-                        py::arg("distance_upper_bound") = std::numeric_limits<double>::infinity());
+                        py::arg("max_results") = 1,
+                        py::arg("max_error") = 0., 
+                        py::arg("max_distance") = std::numeric_limits<double>::infinity());
     py_s2pointindex.def("query",
                         &pys2::s2point_index::query<float>,
                         "Query the index for nearest neighbors (float version).",
                         py::arg("latlon_points"),
-                        py::arg("k") = 1,
-                        py::arg("eps") = 0.,
-                        py::arg("distance_upper_bound") = std::numeric_limits<double>::infinity());
+                        py::arg("max_results") = 1,
+                        py::arg("max_error") = 0.,
+                        py::arg("max_distance") = std::numeric_limits<double>::infinity());
 
     py_s2pointindex.def(
         "get_cell_ids", &pys2::s2point_index::get_cell_ids, py::return_value_policy::move);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-//#include <cmath>
+// #include <cmath>
 #include "pybind11/pybind11.h"
 
 #define FORCE_IMPORT_ARRAY
@@ -58,12 +58,11 @@ PYBIND11_MODULE(pys2index, m)
         cell_ids : ndarray of shape (n_points,), dtype=uint64
             array of cell ids.
 
-    )pbdoc"
-                              );
+    )pbdoc");
     py_s2pointindex.def_static("to_cell_ids",
                                &pys2::s2point_index::to_cell_ids<float>,
                                "Convert latlon points to S2 IDs (float version).");
-    
+
     py_s2pointindex.def("query",
                         &pys2::s2point_index::query<double>,
                         R"pbdoc(
@@ -92,7 +91,7 @@ PYBIND11_MODULE(pys2index, m)
     )pbdoc",
                         py::arg("latlon_points"),
                         py::arg("max_results") = 1,
-                        py::arg("max_error") = 0., 
+                        py::arg("max_error") = 0.,
                         py::arg("max_distance") = std::numeric_limits<double>::infinity());
     py_s2pointindex.def("query",
                         &pys2::s2point_index::query<float>,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+//#include <cmath>
 #include "pybind11/pybind11.h"
 
 #define FORCE_IMPORT_ARRAY
@@ -42,6 +43,27 @@ PYBIND11_MODULE(pys2index, m)
     py_s2pointindex.def(py::init(&pys2::s2point_index::from_points<float>));
     py_s2pointindex.def(py::init(&pys2::s2point_index::from_cell_ids));
 
+    py_s2pointindex.def_static("to_cell_ids",
+                               &pys2::s2point_index::to_cell_ids<double>,
+                               R"pbdoc(
+        Convert latlon points to S2 IDs.
+
+        Parameters
+        ----------
+        latlon_points : ndarray of shape (n_points, 2), dtype=double
+            2-d array of point coordinates (latitude, longitude) in degrees.
+
+        Returns
+        -------
+        cell_ids : ndarray of shape (n_points,), dtype=uint64
+            array of cell ids.
+
+    )pbdoc"
+                              );
+    py_s2pointindex.def_static("to_cell_ids",
+                               &pys2::s2point_index::to_cell_ids<float>,
+                               "Convert latlon points to S2 IDs (float version).");
+    
     py_s2pointindex.def("query",
                         &pys2::s2point_index::query<double>,
                         R"pbdoc(
@@ -59,10 +81,18 @@ PYBIND11_MODULE(pys2index, m)
         positions : ndarray of shape (n_points,), dtype=int
             Indices of the nearest neighbor of the corresponding points.
 
-    )pbdoc");
+    )pbdoc",
+                        py::arg("latlon_points"),
+                        py::arg("k") = 1,
+                        py::arg("eps") = 0., 
+                        py::arg("distance_upper_bound") = std::numeric_limits<double>::infinity());
     py_s2pointindex.def("query",
                         &pys2::s2point_index::query<float>,
-                        "Query the index for nearest neighbors (float version).");
+                        "Query the index for nearest neighbors (float version).",
+                        py::arg("latlon_points"),
+                        py::arg("k") = 1,
+                        py::arg("eps") = 0.,
+                        py::arg("distance_upper_bound") = std::numeric_limits<double>::infinity());
 
     py_s2pointindex.def(
         "get_cell_ids", &pys2::s2point_index::get_cell_ids, py::return_value_policy::move);


### PR DESCRIPTION
Description
----------------
This PR enables parallelization especially for the query using the tbb library. It also extends the query method by additional optional parameters to enable the usage of other `S2ClosestPointQuery`  options.

Note
--------
Thanks for sharing this library. I know that these are a few changes for a single PR. I started experimenting with this library and now created the branch to contribute. Since the library is still at an early dev state without too many open PRs, I thought it might be fine, but please let me know if this should be split into multiple PRs. In any case, happy to get some feedback, because I did not use pybind11 before and therefore took this also as a learning opportunity.

Open Points
------------------
The original tests still pass, which is an indicator for backward compatibility. However, I did not add new tests yet.
I just manually checked that the installation works with and without tbb running the existing tests.