### PR TITLE
Try fix Windows / s2geometry 0.11 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ message(STATUS "Found numpy v${Python_NumPy_VERSION}: ${Python_NumPy_INCLUDE_DIR
 find_package(pybind11 REQUIRED)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
-find_package(s2 REQUIRED)
+find_package(s2 CONFIG REQUIRED)
 
 # Build
 # =====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(pys2index PRIVATE
   xtensor-python
   pybind11::module
   Python::NumPy
-  s2
+  s2::s2
   )
 
 pybind11_extension(pys2index)


### PR DESCRIPTION
Note: this change will break builds with s2geometry version < 0.11 (or 0.11.1).

Either it is OK to bump the minimal s2geometry supported version or we need to refactor the cmake script in other to support older versions (like in https://github.com/paleolimbot/s2geography).

